### PR TITLE
Removed firebase api keys from github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,13 +56,15 @@ buck-out/
 # Bundle artifact
 *.jsbundle
 
-# google-services.json
-# GoogleService-Info.plist
-
 # RNFirebaseStarter
 yarn.lock
 package-lock.json
 
 .watchman-cookie*
 .editorconfig
+
+#API Keys and other secure files
+google-services.json
+GoogleService-Info.plist
 service-account.json
+twilio.json

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ cd AmazonHandMade
 npm i
 ```
 
+#### Download API key files
+There are certain files that shouldn't be hosted on GitHub and so they must be manually downloaded.
+
+There are two Firebase files: google-services.json and GoogleService-Info.plist. These can be downloaded by going to https://console.firebase.google.com/u/0/project/handmade-error-404/settings/general/ and scrolling down to "Your apps". You'll see a download button in the top right of this window, click it for both the Android app and iOS app.
+
+GoogleServices-Info.plist should be placed at /AmazonHandmade/ios/
+
+google-services.json should be placed at /AmazonHandmade/android/app/
+
+Other files may exist, such as for cloud functions, that have instructions in the source code where they are used.
+
 ### Testing for IOS (Android soon to come)
 
 Run the following commands in terminal to get testing set up and run current test for project


### PR DESCRIPTION
Added some files to gitignore and added additional instructions to the README. Will need to rewrite our git history once this is merged to truly remove the file from our github