### PR TITLE
Fixed artisan list not getting updated

### DIFF
--- a/src/screens/ArtisanHub/ArtisanList.js
+++ b/src/screens/ArtisanHub/ArtisanList.js
@@ -52,6 +52,13 @@ export default class ArtisanList extends Component {
     this.fetchArtisans()
   }
 
+  componentDidUpdate(prevProps){
+    console.log(JSON.stringify(this.props.Artisans.length))
+    if ( prevProps.Artisans.length !== this.props.Artisans.length ) {
+      this.searchFilterFunction() //This will take care of updating artisans state
+    }
+  }
+
   fetchArtisans() {
     this.setState({ fetchingArtisans: true })
     this.props.fetchArtisans(this.props.User.uid).then(() => {

--- a/src/screens/ArtisanHub/ArtisanList.js
+++ b/src/screens/ArtisanHub/ArtisanList.js
@@ -52,10 +52,17 @@ export default class ArtisanList extends Component {
     this.fetchArtisans()
   }
 
-  componentDidUpdate(prevProps){
-    console.log(JSON.stringify(this.props.Artisans.length))
-    if ( prevProps.Artisans.length !== this.props.Artisans.length ) {
-      this.searchFilterFunction() //This will take care of updating artisans state
+  // componentDidUpdate(prevProps){
+  //   console.log("prevProps: " + JSON.stringify(prevProps))
+  //   if ( prevProps.Artisans !== this.props.Artisans ) {
+  //     this.searchFilterFunction() //This will take care of updating artisans state
+  //   }
+  // }
+  
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.Artisans != null){
+      console.log("nextProps: " + JSON.stringify(nextProps))
+      this.searchFilterFunction()
     }
   }
 


### PR DESCRIPTION
Redux mapped state was being used before and then it was routed through local component state. This caused it to stop getting updated for new artisans. I added a lifecycle hook to keep it up to date. (componentWillReceiveProps is also the right idea but this is the deprecated way of solving this)